### PR TITLE
Script doesnt work on German Culture

### DIFF
--- a/Student/Modules/06_AddinSecurity/Lab/Scripts/CreateTestCertificateForS2STrust.ps1
+++ b/Student/Modules/06_AddinSecurity/Lab/Scripts/CreateTestCertificateForS2STrust.ps1
@@ -5,8 +5,8 @@ $makecert =  $PSScriptRoot + "\makecert.exe"
 
 $certname = "WingtipAppCertificate01"
 $password = ConvertTo-SecureString "Password1" -AsPlainText -Force
-$startdate = (Get-Date).ToString("MM/dd/yyyy")
-$enddate =  ((Get-Date).AddYears(2)).ToString("MM/dd/yyyy")
+$startdate = (Get-Date).ToString("MM'/'dd'/'yyyy")
+$enddate =  ((Get-Date).AddYears(2)).ToString("MM'/'dd'/'yyyy")
 
 # delete any pre-existing certifcates with same name
 Get-ChildItem Cert:\CurrentUser\My | ? {$_.Subject -eq "CN=$certname"} | Remove-Item


### PR DESCRIPTION
The script doesnt work with a server running on a diffrent time format as the "/" will be replaced with "." by powershell. Executing 
 (Get-Date).ToString("MM/dd/yyyy") will return "06.12.2016" the slashes have to be in single quotation marks.